### PR TITLE
Make The Berkeley Artistic license Open Source by definition

### DIFF
--- a/The Berkeley Artistic license
+++ b/The Berkeley Artistic license
@@ -30,13 +30,13 @@ III: License Terms
 3. You may otherwise modify your copy of this Software in any way, provided that your modifications use this same license or do not distribute the resulting code.
 
 
-4. You may choose to add your name to the contributors list, to allow the Copyright Holder to credit you for your modifications in the Standard Version of the Software.
+4. You may choose to add your name to the contributors list, to allow the Project Developer to credit you for your modifications in the Standard Version of the Software.
 
 
 5. You may distribute your modified copy of this Software in executable form, provided that you make it clear that your distribution of this code is modified, provide a copy of this license, and provide a method to obtain both the source of the Standard Version and the source of your Modified Version. You must also modify your license to point to this project as the origin point, labeling your modified version as a the project, moving any prior origin point to be the primary contributor.
 
 
-6. You may charge a reasonable copying fee for any distribution of this Software on physical media. You may charge any fee you choose for support of this Software. You may not charge a fee for this Software itself. However, you may distribute this Software in aggregate with other (possibly commercial) programs as part of a larger (possibly commercial) software distribution provided that you do not advertise the Standard Version of this Software as a product of your own.
+6. You may charge a reasonable copying fee for any distribution of this Software on physical media. You may charge any fee you choose for support of this Software. You may charge a fee for this Software itself, without restriction. However, you may distribute this Software in aggregate with other (possibly commercial) programs as part of a larger (possibly commercial) software distribution provided that you do not advertise the Standard Version of this Software as a product of your own.
 
 
 7. Neither the name of the project nor the name, username, handle, etc, of the project developer may be used to endorse or promote products derived from this software without specific prior written permission.

--- a/The Berkeley Artistic license
+++ b/The Berkeley Artistic license
@@ -36,7 +36,7 @@ III: License Terms
 5. You may distribute your modified copy of this Software in executable form, provided that you make it clear that your distribution of this code is modified, provide a copy of this license, and provide a method to obtain both the source of the Standard Version and the source of your Modified Version. You must also modify your license to point to this project as the origin point, labeling your modified version as a the project, moving any prior origin point to be the primary contributor.
 
 
-6. You may charge a reasonable copying fee for any distribution of this Software on physical media. You may charge any fee you choose for support of this Software. You may charge a fee for this Software itself, without restriction. However, you may distribute this Software in aggregate with other (possibly commercial) programs as part of a larger (possibly commercial) software distribution provided that you do not advertise the Standard Version of this Software as a product of your own.
+6. You may distribute this Software, with or without fee, provided that you do not advertise the Standard Version of this Software as a product of your own.
 
 
 7. Neither the name of the project nor the name, username, handle, etc, of the project developer may be used to endorse or promote products derived from this software without specific prior written permission.

--- a/license
+++ b/license
@@ -16,11 +16,11 @@ III: License Terms
 
 3. You may otherwise modify your copy of this Software in any way, provided that your modifications use this same license or do not distribute the resulting code.
 
-4. You may choose to add your name to the contributors list, to allow the Copyright Holder to credit you for your modifications in the Standard Version of the Software.
+4. You may choose to add your name to the contributors list, to allow the Project Developer to credit you for your modifications in the Standard Version of the Software.
 
 5. You may distribute your modified copy of this Software in executable form, provided that you make it clear that your distribution of this code is modified, provide a copy of this license, and provide a method to obtain both the source of the Standard Version and the source of your Modified Version. You must also modify your license to point to this project as the origin point, labeling your modified version as a the project, and moving any prior origin point to be the primary Contributor.
 
-6. You may charge a reasonable copying fee for any distribution of this Software on physical media. You may charge any fee you choose for support of this Software. You may not charge a fee for this Software itself. However, you may distribute this Software in aggregate with other (possibly commercial) programs as part of a larger (possibly commercial) software distribution provided that you do not advertise the Standard Version of this Software as a product of your own.
+6. You may distribute this Software, with or without fee, provided that you do not advertise the Standard Version of this Software as a product of your own.
 
 7. Neither the name of the project nor the name, username, handle, etc, of the project developer may be used to endorse or promote products derived from this software without specific prior written permission.
 


### PR DESCRIPTION
Alter a clause to make the license OSD compliant.